### PR TITLE
证书更新

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+本作品采用知识共享 署名-非商业性使用-相同方式共享 3.0 中国大陆 许可协议进行许可。要查看该许可协议，可访问 http://creativecommons.org/licenses/by-nc-sa/3.0/cn/ 或者写信到 Creative Commons, PO Box 1866, Mountain View, CA 94042, USA。

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # RISC-V-book
 A translation project of the RISC-V reader
+
+## LICENSE
+  CC-BY-NC-SA 3.0, 
+  
+  see in http://creativecommons.org/licenses/by-nc-sa/3.0/cn


### PR DESCRIPTION
这个RISC-V手册翻译的仓库已经添加了CC-BY-NC-SA 3.0证书，如果方便的话，请接受pull request。